### PR TITLE
Use `date-fns` named imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,25 @@
 'use strict';
 
 module.exports = {
-  extends: '@zestia/eslint-config/ember-addon'
+  extends: '@zestia/eslint-config/ember-addon',
+
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'date-fns',
+            message:
+              "Please use individual named date-fns imports instead, e.g. `import isValid from 'date-fns/isValid'`"
+          },
+          {
+            name: 'date-fns/esm',
+            message:
+              "Please use individual named date-fns imports instead, e.g. `import isValid from 'date-fns/isValid'`"
+          }
+        ]
+      }
+    ]
+  }
 };

--- a/addon/constraints/date.js
+++ b/addon/constraints/date.js
@@ -1,5 +1,6 @@
 import { isPresent } from '@ember/utils';
-import { isValid, parse } from 'date-fns/esm';
+import isValid from 'date-fns/isValid';
+import parse from 'date-fns/parse';
 
 export default function date(options) {
   return function (value) {

--- a/tests/unit/constraints/date-test.js
+++ b/tests/unit/constraints/date-test.js
@@ -1,7 +1,8 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import date from '@zestia/ember-validation/constraints/date';
-import { enGB, enUS } from 'date-fns/esm/locale';
+import enGB from 'date-fns/locale/en-GB';
+import enUS from 'date-fns/locale/en-US';
 
 module('date', function (hooks) {
   setupTest(hooks);


### PR DESCRIPTION
Swaps over to use named date-fns imports, e.g. `import isValid from 'date-fns/isValid';`.

There's an `ember-auto-import` [bug/issue](https://github.com/ef4/ember-auto-import/issues/121) that means the `date-fns` ESM imports aren't correctly tree shaken leading to the full date-fns lib being bundled.

This PR also adds a linting rule to prevent the ESM imports from being reintroduced.