### PR TITLE
Add whole option for number constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.2.0
+
+- Add whole number constraint option
+
 ## 5.1.2
 
 - Run ember-cli-update

--- a/addon/-private/constraints/number.js
+++ b/addon/-private/constraints/number.js
@@ -7,7 +7,7 @@ export default function number(options = {}) {
       return;
     }
 
-    if (options.natural) {
+    if (options.whole) {
       if (/^([0-9]|[1-9,]+)$/i.test(value)) {
         return;
       }

--- a/addon/-private/constraints/number.js
+++ b/addon/-private/constraints/number.js
@@ -7,7 +7,11 @@ export default function number(options = {}) {
       return;
     }
 
-    if (/^-?[0-9,.]+$/i.test(value)) {
+    if (options.natural) {
+      if (/^([0-9]|[1-9,]+)$/i.test(value)) {
+        return;
+      }
+    } else if (/^-?[0-9,.]+$/i.test(value)) {
       return;
     }
 

--- a/tests/unit/constraints/number-test.js
+++ b/tests/unit/constraints/number-test.js
@@ -67,7 +67,7 @@ module('number', function (hooks) {
   });
 
   test('inputs, natural', function (assert) {
-    assert.expect(9);
+    assert.expect(10);
 
     const options = { natural: true };
 
@@ -75,6 +75,7 @@ module('number', function (hooks) {
     assert.strictEqual(number(options)(''), 'Invalid number');
     assert.strictEqual(number(options)('abc'), 'Invalid number');
     assert.strictEqual(number(options)('-12345'), 'Invalid number');
+    assert.strictEqual(number(options)('123.45'), 'Invalid number');
     assert.strictEqual(number(options)('01'), 'Invalid number');
     assert.strictEqual(number(options)(12345), undefined);
     assert.strictEqual(number(options)('12345'), undefined);

--- a/tests/unit/constraints/number-test.js
+++ b/tests/unit/constraints/number-test.js
@@ -30,16 +30,16 @@ module('number', function (hooks) {
     );
   });
 
-  test('it returns default message if negative with natural option', function (assert) {
+  test('it returns default message if negative with whole option', function (assert) {
     assert.expect(1);
 
-    assert.strictEqual(number({ natural: true })('-24'), 'Invalid number');
+    assert.strictEqual(number({ whole: true })('-24'), 'Invalid number');
   });
 
-  test('it returns default message if fractional with natural option', function (assert) {
+  test('it returns default message if fractional with whole option', function (assert) {
     assert.expect(1);
 
-    assert.strictEqual(number({ natural: true })('2.4'), 'Invalid number');
+    assert.strictEqual(number({ whole: true })('2.4'), 'Invalid number');
   });
 
   test('it returns custom message if invalid', function (assert) {
@@ -66,10 +66,10 @@ module('number', function (hooks) {
     assert.strictEqual(number()('0'), undefined);
   });
 
-  test('inputs, natural', function (assert) {
+  test('inputs, whole', function (assert) {
     assert.expect(10);
 
-    const options = { natural: true };
+    const options = { whole: true };
 
     assert.strictEqual(number(options)(), 'Invalid number');
     assert.strictEqual(number(options)(''), 'Invalid number');

--- a/tests/unit/constraints/number-test.js
+++ b/tests/unit/constraints/number-test.js
@@ -52,34 +52,52 @@ module('number', function (hooks) {
     assert.strictEqual(func('foo@bar'), 'bad number');
   });
 
-  test('inputs', function (assert) {
-    assert.expect(9);
+  test('inputs, non-whole', function (assert) {
+    assert.expect(13);
 
-    assert.strictEqual(number()(), 'Invalid number');
-    assert.strictEqual(number()(''), 'Invalid number');
-    assert.strictEqual(number()('abc'), 'Invalid number');
-    assert.strictEqual(number()(12345), undefined);
-    assert.strictEqual(number()('12345'), undefined);
-    assert.strictEqual(number()('-12345'), undefined);
-    assert.strictEqual(number()('123,456,789'), undefined);
-    assert.strictEqual(number()('123.456'), undefined);
-    assert.strictEqual(number()('0'), undefined);
+    const validExamples = [
+      12345,
+      '12345',
+      -12345,
+      '-12345',
+      '123,456,789',
+      123.45,
+      '123.45',
+      '01',
+      0,
+      '0'
+    ];
+    const invalidExamples = [null, '', 'abc'];
+
+    testInputs(assert, {}, validExamples, invalidExamples);
   });
 
   test('inputs, whole', function (assert) {
-    assert.expect(10);
+    assert.expect(14);
 
     const options = { whole: true };
+    const validExamples = [0, '0', 12345, '12345', 123456789, '123,456,789'];
+    const invalidExamples = [
+      null,
+      '',
+      'abc',
+      -12345,
+      '-12345',
+      123.45,
+      '123.45',
+      '01'
+    ];
 
-    assert.strictEqual(number(options)(), 'Invalid number');
-    assert.strictEqual(number(options)(''), 'Invalid number');
-    assert.strictEqual(number(options)('abc'), 'Invalid number');
-    assert.strictEqual(number(options)('-12345'), 'Invalid number');
-    assert.strictEqual(number(options)('123.45'), 'Invalid number');
-    assert.strictEqual(number(options)('01'), 'Invalid number');
-    assert.strictEqual(number(options)(12345), undefined);
-    assert.strictEqual(number(options)('12345'), undefined);
-    assert.strictEqual(number(options)('123,456,789'), undefined);
-    assert.strictEqual(number(options)('0'), undefined);
+    testInputs(assert, options, validExamples, invalidExamples);
   });
+
+  function testInputs(assert, options, validExamples, invalidExamples) {
+    validExamples.forEach((input) => {
+      assert.strictEqual(number(options)(input), undefined);
+    });
+
+    invalidExamples.forEach((input) => {
+      assert.strictEqual(number(options)(input), 'Invalid number');
+    });
+  }
 });

--- a/tests/unit/constraints/number-test.js
+++ b/tests/unit/constraints/number-test.js
@@ -8,7 +8,7 @@ module('number', function (hooks) {
     setMessageFn(defaultMessageFn);
   });
 
-  test('is returns nothing when valid', function (assert) {
+  test('it returns nothing when valid', function (assert) {
     assert.expect(1);
 
     assert.strictEqual(number()('123'), undefined);
@@ -20,7 +20,7 @@ module('number', function (hooks) {
     assert.strictEqual(number()('xyz'), 'Invalid number');
   });
 
-  test('it returns nothing if invalid, but options', function (assert) {
+  test('it returns nothing if invalid, but optional', function (assert) {
     assert.expect(1);
 
     assert.strictEqual(
@@ -28,6 +28,18 @@ module('number', function (hooks) {
       undefined,
       'returns nothing if invalid, but optional'
     );
+  });
+
+  test('it returns default message if negative with natural option', function (assert) {
+    assert.expect(1);
+
+    assert.strictEqual(number({ natural: true })('-24'), 'Invalid number');
+  });
+
+  test('it returns default message if fractional with natural option', function (assert) {
+    assert.expect(1);
+
+    assert.strictEqual(number({ natural: true })('2.4'), 'Invalid number');
   });
 
   test('it returns custom message if invalid', function (assert) {
@@ -41,7 +53,7 @@ module('number', function (hooks) {
   });
 
   test('inputs', function (assert) {
-    assert.expect(8);
+    assert.expect(9);
 
     assert.strictEqual(number()(), 'Invalid number');
     assert.strictEqual(number()(''), 'Invalid number');
@@ -51,5 +63,22 @@ module('number', function (hooks) {
     assert.strictEqual(number()('-12345'), undefined);
     assert.strictEqual(number()('123,456,789'), undefined);
     assert.strictEqual(number()('123.456'), undefined);
+    assert.strictEqual(number()('0'), undefined);
+  });
+
+  test('inputs, natural', function (assert) {
+    assert.expect(9);
+
+    const options = { natural: true };
+
+    assert.strictEqual(number(options)(), 'Invalid number');
+    assert.strictEqual(number(options)(''), 'Invalid number');
+    assert.strictEqual(number(options)('abc'), 'Invalid number');
+    assert.strictEqual(number(options)('-12345'), 'Invalid number');
+    assert.strictEqual(number(options)('01'), 'Invalid number');
+    assert.strictEqual(number(options)(12345), undefined);
+    assert.strictEqual(number(options)('12345'), undefined);
+    assert.strictEqual(number(options)('123,456,789'), undefined);
+    assert.strictEqual(number(options)('0'), undefined);
   });
 });


### PR DESCRIPTION
The option `{ whole: true }` accepts non negative, whole numbers.
